### PR TITLE
支持配置阿里云多帐号

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,18 @@ deploy/data/mysql-data/
 deploy/data/project/
 hubble/Application/Runtime
 orion/orion
-jupiter/conf/jupiter.json
 jupiter/conf/zhaowei9.pem
 orion/conf/app.conf
+orion/go_build_orion
 
+#jupiter
+jupiter/.idea/
+jupiter/vendor/
+jupiter/conf/jupiter.json
+
+#orion
+orion/vendor/
+orion/.idea/
 
 # eclipse ignore
 .settings/

--- a/db_init/sql/jupiter.sql
+++ b/db_init/sql/jupiter.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS `cluster` (
   `data_disk_size` int(11) NOT NULL DEFAULT '0',
   `data_disk_num` int(11) NOT NULL DEFAULT '0',
   `data_disk_category` varchar(255) NOT NULL DEFAULT '',
+  `cloud_key_id` varchar(100) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -159,10 +160,10 @@ UNLOCK TABLES;
 
 LOCK TABLES `cluster` WRITE;
 INSERT INTO `cluster` VALUES 
-    (1,'16Core16G经典网','aliyun',0,'',NOW(),NULL,16,16,'ecs.c2.medium','centos7u2_64_40G_cloudinit_20160728.raw','','key',1,1,'cloud_efficiency',100,1,'cloud_efficiency'),
-    (2,'4Core8G经典网',  'aliyun',0,'',NOW(),NULL,4, 8, 'ecs.n2.large', 'centos7u2_64_40G_cloudinit_20160728.raw','','key',1,1,'cloud_efficiency',100,1,'cloud_efficiency'),
-    (3,'1Core1G经典网',  'aliyun',0,'',NOW(),NULL,1, 1, 'ecs.n1.tiny',  'centos7u2_64_40G_cloudinit_20160728.raw','','key',1,1,'cloud_efficiency',100,1,'cloud_efficiency'),
-    (4,'1Core-1Gib',    'aws',   0,'',NOW(),NULL,1, 1, 't2.micro',     'ami-3965b454',                           '','zhaowei9',2,3,'standard'     ,100,1,'standard'        )
+    (1,'16Core16G经典网','aliyun',0,'',NOW(),NULL,16,16,'ecs.c2.medium','centos7u2_64_40G_cloudinit_20160728.raw','','key',1,1,'cloud_efficiency',100,1,'cloud_efficiency',''),
+    (2,'4Core8G经典网',  'aliyun',0,'',NOW(),NULL,4, 8, 'ecs.n2.large', 'centos7u2_64_40G_cloudinit_20160728.raw','','key',1,1,'cloud_efficiency',100,1,'cloud_efficiency',''),
+    (3,'1Core1G经典网',  'aliyun',0,'',NOW(),NULL,1, 1, 'ecs.n1.tiny',  'centos7u2_64_40G_cloudinit_20160728.raw','','key',1,1,'cloud_efficiency',100,1,'cloud_efficiency',''),
+    (4,'1Core-1Gib',    'aws',   0,'',NOW(),NULL,1, 1, 't2.micro',     'ami-3965b454',                           '','zhaowei9',2,3,'standard'     ,100,1,'standard'        ,'')
     ;
 UNLOCK TABLES;
 

--- a/deploy/conf/jupiter.json
+++ b/deploy/conf/jupiter.json
@@ -1,9 +1,5 @@
 {
     "Password": "ASDqwe123",
-    "KeyId": "your_aliyun_key_id",
-    "KeySecret": "your_aliyun_secret",
-    "AwsKeyId":  "your_aws_key_id",
-    "AwsKeySecret": "your_aws_key_secret",
     "OpIp": "your_op_ip",
     "OpPort": "your_op_port",
     "OpUserName": "your_op_username",
@@ -15,5 +11,17 @@
         "GetOctansUrl": "host_ip:8999",
         "DefaultRole": "init",
         "ForkNum": 5
-    }
+    },
+    "CloudAccounts": [
+        {
+            "KeyId": "your_aliyun_key_id",
+            "KeySecret": "your_aliyun_secret",
+            "VendorType": "aliyun"
+        },
+        {
+            "KeyId": "your_aws_key_id",
+            "KeySecret": "your_aws_key_secret",
+            "VendorType": "aws"
+        }
+    ]
 }

--- a/document/install.md
+++ b/document/install.md
@@ -34,7 +34,7 @@ OPENDCP主要由以下几个模块构成:
         - <p>编辑 conf/hubble_conf.php, 修改配置项 'HUBBLE_HOST','HUBBLE_ANSIBLE_HTTP' 和 'HUBBLE_SLB_HTTP' 为本机IP。</p>
         - <p>编辑 docker-compose.yml, 找到配置项 'imagebuild', 修改  'SERVER_IP' 为本机IP, 'HARBOR_ADDRESS'改为Harbor服务器的地址.</p>
         - <p>在conf/octans_roles/init/files/docker里，增加--insecure-registry 'harbor_ip:12380'。</p>
-        - <p>编辑 conf/jupiter.json, 修改`KeyId`和`KeySecret`为您的阿里云账号和密码。</p>
+        - <p>编辑 conf/jupiter.json, 修改CloudAccounts下的内容，CloudAccounts下可配置多个云厂商账户，VendorType为aliyun的账户可配置多个，VendorType为aws的目前只需要配置一个即可，然后修改`KeyId`和`KeySecret`为您的云厂商账号和密码。</p>
         - <p>编辑 conf/web_conf.php, 修改  REPOS_DOMAIN 为 Harbor部署的IP。</p>
         - <span id="auth">关于登录系统和认证</span>
             - 当选择本地认证方式时，用户需要自行维护所有用户的登录账号。缺省只有管理员账号“root”能够登录，密码是“admin”。登录成功后，到导航栏 系统管理 -> 用户管理 可以增加管理用户。

--- a/jupiter/conf/conf.go
+++ b/jupiter/conf/conf.go
@@ -40,18 +40,21 @@ var (
 )
 
 type Configuration struct {
-	Password     string
-	KeyId        string
-	KeySecret    string
-	AwsKeyId     string
-	AwsKeySecret string
-	OpIp         string
-	OpPort       string
-	OpUserName   string
-	OpPassWord   string
-	BufferSize   int
-	Ansible      *Ansible
-	KeyDir       string
+	Password      string
+	OpIp          string
+	OpPort        string
+	OpUserName    string
+	OpPassWord    string
+	BufferSize    int
+	Ansible       *Ansible
+	KeyDir        string
+	CloudAccounts []*CloudAccount
+}
+
+type CloudAccount struct {
+	KeyID      string //ak
+	KeySecret  string //sk
+	VendorType string //云厂商类型，支持aliyun, aws
 }
 
 type Ansible struct {
@@ -64,6 +67,45 @@ type Ansible struct {
 func GetConfig() (*Configuration, error) {
 	c, err := getConfigFromFile()
 	return c, err
+}
+
+//获取一个默认账号
+func GetDefaultCloudAccount() *CloudAccount {
+	if len(Config.CloudAccounts) <= 0 {
+		return nil
+	}
+	for _, v := range Config.CloudAccounts {
+		if v.VendorType == "aliyun" {
+			return v
+		}
+	}
+	return &CloudAccount{}
+}
+
+//获取一个aws默认账号
+func GetAWSCloudAccount() *CloudAccount {
+	if len(Config.CloudAccounts) <= 0 {
+		return nil
+	}
+	for _, v := range Config.CloudAccounts {
+		if v.VendorType == "aws" {
+			return v
+		}
+	}
+	return &CloudAccount{}
+}
+
+//根据KeyID获取云账号
+func GetCloudAccountByKeyId(id string) *CloudAccount {
+	if len(Config.CloudAccounts) <= 0 {
+		return nil
+	}
+	for _, v := range Config.CloudAccounts {
+		if v.KeyID == id {
+			return v
+		}
+	}
+	return nil
 }
 
 func getConfigFromFile() (*Configuration, error) {

--- a/jupiter/conf/jupiter-tpl.json
+++ b/jupiter/conf/jupiter-tpl.json
@@ -1,12 +1,22 @@
 {
     "Password": "",
-    "KeyId": "",
-    "KeySecret": "",
     "KeyDir": "./keys",
     "Ansible": {
         "Url": "",
         "GetOctansUrl": "",
         "DefaultRole": "",
         "ForkNum": 5
-    }
+    },
+    "CloudAccounts": [
+        {
+            "KeyId": "your_aliyun_key_id",
+            "KeySecret": "your_aliyun_secret",
+            "VendorType": "aliyun"
+        },
+        {
+            "KeyId": "your_aws_key_id",
+            "KeySecret": "your_aws_secret",
+            "VendorType": "aws"
+        }
+    ]
 }

--- a/jupiter/controllers/base.go
+++ b/jupiter/controllers/base.go
@@ -66,6 +66,11 @@ var (
 	SuccessResp = ApiResponse{}
 
 	// Error
+	NotEnoughCloudAccountResp = ApiResponse{
+		Code: 13001,
+		Msg:  "Cloud accounts config is missing!",
+	}
+
 	JsonFormatFaildResp = ApiResponse{
 		Code: 12999,
 		Msg:  "Please input the correct json format!",

--- a/jupiter/controllers/instance.go
+++ b/jupiter/controllers/instance.go
@@ -298,8 +298,9 @@ func (ic *InstanceController) GetZones() {
 func (ic *InstanceController) GetVpcs() {
 	provider := ic.GetString(":provider")
 	regionId := ic.GetString(":regionId")
+	keyId := ic.GetString("keyId")
 	// pageNumber 起始值为1，pageSize 最大值为50
-	vpcs, err := instance.GetVpcs(provider, regionId, 1, 50)
+	vpcs, err := instance.GetVpcs(provider, regionId, keyId, 1, 50)
 	if err != nil {
 		beego.Error(err)
 		ic.RespServiceError(err)
@@ -319,7 +320,8 @@ func (ic *InstanceController) GetSubnets() {
 	provider := ic.GetString(":provider")
 	zoneId := ic.GetString(":zoneId")
 	vpcId := ic.GetString(":vpcId")
-	subnets, err := instance.GetSubnets(provider, zoneId, vpcId)
+	keyId := ic.GetString("keyId", "")
+	subnets, err := instance.GetSubnets(provider, zoneId, vpcId, keyId)
 	if err != nil {
 		beego.Error(err)
 		ic.RespServiceError(err)
@@ -388,7 +390,8 @@ func (ic *InstanceController) ListDiskCategory() {
 func (ic *InstanceController) GetImages() {
 	provider := ic.GetString(":provider")
 	regionId := ic.GetString(":regionId")
-	images, err := instance.GetImages(provider, regionId)
+	keyId := ic.GetString("keyId")
+	images, err := instance.GetImages(provider, regionId, keyId)
 	if err != nil {
 		beego.Error(err)
 		ic.RespServiceError(err)
@@ -408,7 +411,8 @@ func (ic *InstanceController) GetSecurityGroup() {
 	provider := ic.GetString(":provider")
 	regionId := ic.GetString(":regionId")
 	vpcId := ic.GetString("vpcId")
-	securityGroup, err := instance.GetSecurityGroup(provider, regionId, vpcId)
+	keyId := ic.GetString("keyId", "")
+	securityGroup, err := instance.GetSecurityGroup(provider, regionId, vpcId, keyId)
 	if err != nil {
 		beego.Error(err)
 		ic.RespServiceError(err)

--- a/jupiter/models/backendserver.go
+++ b/jupiter/models/backendserver.go
@@ -17,8 +17,6 @@
  *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
  */
 
-
-
 package models
 
 type BackendServers struct {
@@ -35,5 +33,6 @@ type BackendServer struct {
 
 type BackendServerRequest struct {
 	LoadBalancerId    string
+	KeyId             string
 	BackendServerList []BackendServer
 }

--- a/jupiter/models/cluster.go
+++ b/jupiter/models/cluster.go
@@ -8,8 +8,8 @@ type Cluster struct {
 	Id   int64 `orm:"pk;auto"`
 	Name string
 	//OrganizationId     int64
-	Provider           string
-	LastestPartNum     int
+	Provider       string
+	LastestPartNum int
 	//PartOfInstances    []*InstancesResp `orm:"-"`
 	Desc               string
 	CreateTime         time.Time
@@ -28,7 +28,8 @@ type Cluster struct {
 	DataDiskNum        int
 	DataDiskCategory   string
 	//OpenStack参数
-	FlavorId	   string
+	FlavorId   string
+	CloudKeyId string `json:"Account"`
 }
 
 type Replication struct {
@@ -41,11 +42,11 @@ type Replication struct {
 }
 
 type Network struct {
-	Id            int64 `orm:"pk;auto"`
-	VpcId         string
-	SubnetId      string
-	SecurityGroup string
-	InternetChargeType string
+	Id                      int64 `orm:"pk;auto"`
+	VpcId                   string
+	SubnetId                string
+	SecurityGroup           string
+	InternetChargeType      string
 	InternetMaxBandwidthOut int
 }
 
@@ -71,14 +72,13 @@ func (u *Zone) TableUnique() [][]string {
 	}
 }
 
-
 type Detail struct {
-	Id             int64      	`orm:"pk;auto"`
-	InstanceNumber string 		`orm:"type(text);null"`
-	RunningTime    time.Time 	`orm:"auto_now_add;type(datetime)"`
+	Id             int64     `orm:"pk;auto"`
+	InstanceNumber string    `orm:"type(text);null"`
+	RunningTime    time.Time `orm:"auto_now_add;type(datetime)"`
 }
 
 type InstanceDetail struct {
-	InstanceNumber   map[string]int	`json:"number"`
-	RunningTime		 string			`json:"time"`
+	InstanceNumber map[string]int `json:"number"`
+	RunningTime    string         `json:"time"`
 }

--- a/jupiter/models/listener.go
+++ b/jupiter/models/listener.go
@@ -17,8 +17,6 @@
  *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
  */
 
-
-
 package models
 
 type Listener struct {
@@ -57,4 +55,6 @@ type Listener struct {
 
 	AccessControlStatus string //'是否开启访问控制。取值：open_white_list | close'
 	SourceItems         string //'访问控制列表。支持ip地址或ip地址段的输入，多个ip地址或ip地址段间用”,”分割。'
+
+	KeyId string `json:"keyId"` //阿里云keyid
 }

--- a/jupiter/models/loadbalancer.go
+++ b/jupiter/models/loadbalancer.go
@@ -17,8 +17,6 @@
  *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
  */
 
-
-
 package models
 
 type LoadBalancer struct {
@@ -37,4 +35,6 @@ type LoadBalancer struct {
 	CreateTime         string `json:"CreateTime"`         //'负载均衡实例创建时间'
 	RegionIdAlias      string `json:"RegionIdAlias"`      //'负载均衡实例所属的Region编号别名'
 	Reason             string `json:"Reason"`
+	KeyId              string `json:"keyId"`
+	LoadBalancerSpec   string `json:"LoadBalancerSpec"` //负载均衡规格
 }

--- a/jupiter/provider/aws/aws.go
+++ b/jupiter/provider/aws/aws.go
@@ -77,7 +77,7 @@ func (driver awsProvider) ListInternetChargeType() []string {
 }
 
 func (driver awsProvider) Create(input *models.Cluster, number int) ([]string, []error) {
-	driver.client.Config.Credentials = credentials.NewStaticCredentials(conf.Config.AwsKeyId, conf.Config.AwsKeySecret, "")
+	driver.client.Config.Credentials = credentials.NewStaticCredentials(conf.GetAWSCloudAccount().KeyID, conf.GetAWSCloudAccount().KeySecret, "")
 
 	runResult, err := driver.client.RunInstances(&ec2.RunInstancesInput{
 		// An Amazon Linux AMI ID for imageId (such as t2.micro instances) in the cn-north-1 region
@@ -611,7 +611,7 @@ func (driver awsProvider) WaitToStartInstance(instanceId string) bool {
 	return true
 }
 
-func new() (provider.ProviderDriver, error) {
+func new(keyId ...string) (provider.ProviderDriver, error) {
 	return  newProvider()
 }
 
@@ -620,7 +620,8 @@ func newProvider() (provider.ProviderDriver, error) {
 		Region: aws.String("cn-north-1"),
 	}))
 	client := ec2.New(sess)
-	client.Config.Credentials = credentials.NewStaticCredentials(conf.Config.KeyId, conf.Config.KeySecret, "")
+	awsConf := conf.GetAWSCloudAccount()
+	client.Config.Credentials = credentials.NewStaticCredentials(awsConf.KeyID, awsConf.KeySecret, "")
 	ret := awsProvider{
 		client: client,
 	}

--- a/jupiter/provider/openstack/openstack.go
+++ b/jupiter/provider/openstack/openstack.go
@@ -391,7 +391,7 @@ func waitForSpecific(f func() bool, maxAttempts int, waitInterval time.Duration)
 
 
 
-func new() (provider.ProviderDriver, error){
+func new(keyId ...string) (provider.ProviderDriver, error){
 
 	return newProvider()
 }

--- a/jupiter/provider/provider.go
+++ b/jupiter/provider/provider.go
@@ -26,7 +26,6 @@ import (
 	"sort"
 	"time"
 	"weibo.com/opendcp/jupiter/models"
-
 )
 
 type ProviderDriver interface {
@@ -52,7 +51,7 @@ type ProviderDriver interface {
 
 }
 
-type ProviderDriverFunc func() (ProviderDriver, error)
+type ProviderDriverFunc func(keyId ...string) (ProviderDriver, error)
 
 var registeredPlugins = map[string](ProviderDriverFunc){}
 
@@ -60,13 +59,21 @@ func RegisterProviderDriver(name string, f ProviderDriverFunc) {
 	registeredPlugins[name] = f
 }
 
-func New(name string) (ProviderDriver, error) {
+func New(name string, keyId ...string) (ProviderDriver, error) {
 	if name == "" {
 		return nil, fmt.Errorf("the provider cannot be null.")
 	}
+
 	f, ok := registeredPlugins[name]
 	if !ok {
 		return nil, fmt.Errorf("unknown backend provider driver: %s", name)
+	}
+
+	if name == "aliyun" {
+		//阿里云多帐号支持
+		if len(keyId) > 0 {
+			return f(keyId...)
+		}
 	}
 	return f()
 }

--- a/jupiter/routers/commentsRouter_controllers.go
+++ b/jupiter/routers/commentsRouter_controllers.go
@@ -468,4 +468,10 @@ func init() {
 			AllowHTTPMethods: []string{"get"},
 			Params: nil})
 
+	beego.GlobalControllerRouter["weibo.com/opendcp/jupiter/controllers:ClusterController"] = append(beego.GlobalControllerRouter["weibo.com/opendcp/jupiter/controllers:ClusterController"],
+		beego.ControllerComments{
+			Method: "ListAccount",
+			Router: `/list_account/:vendorType`,
+			AllowHTTPMethods: []string{"get"},
+			Params: nil})
 }

--- a/jupiter/service/cluster/cluster.go
+++ b/jupiter/service/cluster/cluster.go
@@ -51,7 +51,7 @@ func GetCluster(clusterId int64) (*models.Cluster, error) {
 
 func CreateCluster(cluster *models.Cluster) (int64, error) {
 	cluster.CreateTime = time.Now()
-	providerDriver, err := provider.New(cluster.Provider)
+	providerDriver, err := provider.New(cluster.Provider, cluster.CloudKeyId)
 	if err != nil {
 		return 0, err
 	}
@@ -90,7 +90,7 @@ func DeleteCluster(clusterId int64) (bool, error) {
 }
 
 func Expand(cluster *models.Cluster, num int, correlationId string) ([]string, error) {
-	providerDriver, err := provider.New(cluster.Provider)
+	providerDriver, err := provider.New(cluster.Provider, cluster.CloudKeyId)
 	if err != nil {
 		return nil, err
 	}

--- a/jupiter/service/instance/instance.go
+++ b/jupiter/service/instance/instance.go
@@ -44,7 +44,7 @@ const (
 )
 
 func CreateOne(cluster *models.Cluster) (string, error) {
-	providerDriver, err := provider.New(cluster.Provider)
+	providerDriver, err := provider.New(cluster.Provider, cluster.CloudKeyId)
 	if err != nil {
 		return "", err
 	}
@@ -73,7 +73,8 @@ func StartOne(instanceId string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	providerDriver, err := provider.New(ins.Provider)
+
+	providerDriver, err := provider.New(ins.Provider, ins.Cluster.CloudKeyId)
 	if err != nil {
 		return false, err
 	}
@@ -89,7 +90,7 @@ func StopOne(instanceId string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	providerDriver, err := provider.New(ins.Provider)
+	providerDriver, err := provider.New(ins.Provider, ins.Cluster.CloudKeyId)
 	if err != nil {
 		return false, err
 	}
@@ -114,7 +115,7 @@ func DeleteOne(instanceId, correlationId string) error {
 	}
 	logstore.Info(correlationId, instanceId, "2. Delete instance from cloud")
 	if ins.Provider != PhyDev {
-		providerDriver, err := provider.New(ins.Provider)
+		providerDriver, err := provider.New(ins.Provider, ins.Cluster.CloudKeyId)
 		if err != nil {
 			logstore.Error(correlationId, instanceId, err)
 			return err
@@ -211,7 +212,7 @@ func GetProviders() ([]string, error) {
 }
 
 func GetRegions(providerName string) ([]models.Region, error) {
-	providerDriver, err := provider.New(providerName)
+	providerDriver, err := provider.New(providerName, conf.GetDefaultCloudAccount().KeyID)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +224,7 @@ func GetRegions(providerName string) ([]models.Region, error) {
 }
 
 func GetZones(providerName string, regionId string) ([]models.AvailabilityZone, error) {
-	providerDriver, err := provider.New(providerName)
+	providerDriver, err := provider.New(providerName, conf.GetDefaultCloudAccount().KeyID)
 	if err != nil {
 		return nil, err
 	}
@@ -234,8 +235,8 @@ func GetZones(providerName string, regionId string) ([]models.AvailabilityZone, 
 	return ret.AvailabilityZones, nil
 }
 
-func GetVpcs(providerName string, regionId string, pageNumber int, pageSize int) ([]models.Vpc, error) {
-	providerDriver, err := provider.New(providerName)
+func GetVpcs(providerName string, regionId string, keyId string, pageNumber int, pageSize int) ([]models.Vpc, error) {
+	providerDriver, err := provider.New(providerName, keyId)
 	if err != nil {
 		return nil, err
 	}
@@ -246,8 +247,8 @@ func GetVpcs(providerName string, regionId string, pageNumber int, pageSize int)
 	return ret.Vpcs, nil
 }
 
-func GetSubnets(providerName string, zoneId string, vpcId string) ([]models.Subnet, error) {
-	providerDriver, err := provider.New(providerName)
+func GetSubnets(providerName string, zoneId string, vpcId string, keyId string) ([]models.Subnet, error) {
+	providerDriver, err := provider.New(providerName, keyId)
 	if err != nil {
 		return nil, err
 	}
@@ -258,8 +259,8 @@ func GetSubnets(providerName string, zoneId string, vpcId string) ([]models.Subn
 	return ret.Subnets, nil
 }
 
-func GetImages(providerName string, regionId string) ([]models.Image, error) {
-	providerDriver, err := provider.New(providerName)
+func GetImages(providerName string, regionId string, keyId string) ([]models.Image, error) {
+	providerDriver, err := provider.New(providerName, keyId)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func GetImages(providerName string, regionId string) ([]models.Image, error) {
 }
 
 func ListInstanceTypes(providerName string) ([]string, error) {
-	providerDriver, err := provider.New(providerName)
+	providerDriver, err := provider.New(providerName, conf.GetDefaultCloudAccount().KeyID)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +284,7 @@ func ListInstanceTypes(providerName string) ([]string, error) {
 }
 
 func ListInternetChargeTypes(providerName string) ([]string, error) {
-	providerDriver, err := provider.New(providerName)
+	providerDriver, err := provider.New(providerName, conf.GetDefaultCloudAccount().KeyID)
 	if err != nil {
 		return nil, err
 	}
@@ -291,15 +292,15 @@ func ListInternetChargeTypes(providerName string) ([]string, error) {
 }
 
 func ListDiskCategory(providerName string) ([]string, error) {
-	providerDriver, err := provider.New(providerName)
+	providerDriver, err := provider.New(providerName, conf.GetDefaultCloudAccount().KeyID)
 	if err != nil {
 		return nil, err
 	}
 	return providerDriver.ListDiskCategory(), nil
 }
 
-func GetSecurityGroup(providerName string, regionId string, vpcId string) ([]models.SecurityGroup, error) {
-	providerDriver, err := provider.New(providerName)
+func GetSecurityGroup(providerName string, regionId string, vpcId string, keyId string) ([]models.SecurityGroup, error) {
+	providerDriver, err := provider.New(providerName, keyId)
 	if err != nil {
 		return nil, err
 	}

--- a/jupiter/service/slb/backendserver.go
+++ b/jupiter/service/slb/backendserver.go
@@ -25,32 +25,32 @@ import (
 	"github.com/jiangshengwu/aliyun-sdk-for-go/slb"
 )
 
-func AddBackendServers(loadBalancerId string, backendServers string) (slb.AddBackendServersResponse, error) {
-	cli := GetSlbClient()
+func AddBackendServers(loadBalancerId string, backendServers string, keyId string) (slb.AddBackendServersResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["BackendServers"] = backendServers
 	return cli.BackendServer.AddBackendServers(params)
 }
 
-func RemoveBackendServers(loadBalancerId string, backendServers string) (slb.RemoveBackendServersResponse, error) {
-	cli := GetSlbClient()
+func RemoveBackendServers(loadBalancerId string, backendServers string, keyId string) (slb.RemoveBackendServersResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["BackendServers"] = backendServers
 	return cli.BackendServer.RemoveBackendServers(params)
 }
 
-func SetBackendServers(loadBalancerId string, backendServers string) (slb.SetBackendServersResponse, error) {
-	cli := GetSlbClient()
+func SetBackendServers(loadBalancerId string, backendServers string, keyId string) (slb.SetBackendServersResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["BackendServers"] = backendServers
 	return cli.BackendServer.SetBackendServers(params)
 }
 
-func DescribeHealthStatus(loadBalancerId string, listenerPort ...int) (slb.DescribeHealthStatusResponse, error) {
-	cli := GetSlbClient()
+func DescribeHealthStatus(loadBalancerId string, keyId string, listenerPort ...int) (slb.DescribeHealthStatusResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	if len(listenerPort) == 1 {

--- a/jupiter/service/slb/base.go
+++ b/jupiter/service/slb/base.go
@@ -28,16 +28,36 @@ import (
 )
 
 var globalSlbClient *slb.SlbClient
+var globalSlbClientMap map[string]*slb.SlbClient
 var once sync.Once
+
+func init()  {
+	globalSlbClientMap = make(map[string]*slb.SlbClient)
+}
 
 // GetOrmer :set ormer singleton
 func GetSlbClient() *slb.SlbClient {
 	once.Do(func() {
 		globalSlbClient = slb.NewClient(
-			conf.Config.KeyId,
-			conf.Config.KeySecret,
+			conf.GetDefaultCloudAccount().KeyID,
+			conf.GetDefaultCloudAccount().KeySecret,
 			"",
 		)
 	})
 	return globalSlbClient
+}
+
+// GetOrmer :set ormer singleton
+func GetSlbClientByKeyId(keyId string) *slb.SlbClient {
+	account := conf.GetCloudAccountByKeyId(keyId)
+	if v, ok := globalSlbClientMap[account.KeyID]; ok {
+		return v
+	} else {
+		globalSlbClientMap[account.KeyID] = slb.NewClient(
+			account.KeyID,
+			account.KeySecret,
+			"",
+		)
+		return globalSlbClientMap[account.KeyID]
+	}
 }

--- a/jupiter/service/slb/listener.go
+++ b/jupiter/service/slb/listener.go
@@ -27,7 +27,7 @@ import (
 )
 
 func CreateLoadBalancerHTTPListener(listener models.Listener) (slb.CreateLoadBalancerHTTPListenerResponse, error) {
-	cli := GetSlbClient()
+	cli := GetSlbClientByKeyId(listener.KeyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = listener.LoadBalancerId
 	params["ListenerPort"] = listener.ListenerPort
@@ -60,7 +60,7 @@ func CreateLoadBalancerHTTPListener(listener models.Listener) (slb.CreateLoadBal
 }
 
 func CreateLoadBalancerHTTPSListener(listener models.Listener) (slb.CreateLoadBalancerHTTPSListenerResponse, error) {
-	cli := GetSlbClient()
+	cli := GetSlbClientByKeyId(listener.KeyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = listener.LoadBalancerId
 	params["ListenerPort"] = listener.ListenerPort
@@ -94,7 +94,7 @@ func CreateLoadBalancerHTTPSListener(listener models.Listener) (slb.CreateLoadBa
 }
 
 func CreateLoadBalancerTCPListener(listener models.Listener) (slb.CreateLoadBalancerTCPListenerResponse, error) {
-	cli := GetSlbClient()
+	cli := GetSlbClientByKeyId(listener.KeyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = listener.LoadBalancerId
 	params["ListenerPort"] = listener.ListenerPort
@@ -119,7 +119,7 @@ func CreateLoadBalancerTCPListener(listener models.Listener) (slb.CreateLoadBala
 }
 
 func CreateLoadBalancerUDPListener(listener models.Listener) (slb.CreateLoadBalancerUDPListenerResponse, error) {
-	cli := GetSlbClient()
+	cli := GetSlbClientByKeyId(listener.KeyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = listener.LoadBalancerId
 	params["ListenerPort"] = listener.ListenerPort
@@ -143,32 +143,32 @@ func CreateLoadBalancerUDPListener(listener models.Listener) (slb.CreateLoadBala
 	return cli.Listener.CreateLoadBalancerUDPListener(params)
 }
 
-func DeleteLoadBalancerListener(loadBalancerId string, listenerPort int) (slb.DeleteLoadBalancerListenerResponse, error) {
-	cli := GetSlbClient()
+func DeleteLoadBalancerListener(keyId string, loadBalancerId string, listenerPort int) (slb.DeleteLoadBalancerListenerResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
 	return cli.Listener.DeleteLoadBalancerListener(params)
 }
 
-func StartLoadBalancerListener(loadBalancerId string, listenerPort int) (slb.StartLoadBalancerListenerResponse, error) {
-	cli := GetSlbClient()
+func StartLoadBalancerListener(keyId string, loadBalancerId string, listenerPort int) (slb.StartLoadBalancerListenerResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
 	return cli.Listener.StartLoadBalancerListener(params)
 }
 
-func StopLoadBalancerListener(loadBalancerId string, listenerPort int) (slb.StopLoadBalancerListenerResponse, error) {
-	cli := GetSlbClient()
+func StopLoadBalancerListener(keyId string, loadBalancerId string, listenerPort int) (slb.StopLoadBalancerListenerResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
 	return cli.Listener.StopLoadBalancerListener(params)
 }
 
-func SetListenerAccessControlStatus(loadBalancerId string, listenerPort int, accessControlStatus string) (slb.SetListenerAccessControlStatusResponse, error) {
-	cli := GetSlbClient()
+func SetListenerAccessControlStatus(keyId string, loadBalancerId string, listenerPort int, accessControlStatus string) (slb.SetListenerAccessControlStatusResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
@@ -176,8 +176,8 @@ func SetListenerAccessControlStatus(loadBalancerId string, listenerPort int, acc
 	return cli.Listener.SetListenerAccessControlStatus(params)
 }
 
-func AddListenerWhiteListItem(loadBalancerId string, listenerPort int, sourceItems string) (slb.AddListenerWhiteListItemResponse, error) {
-	cli := GetSlbClient()
+func AddListenerWhiteListItem(keyId string, loadBalancerId string, listenerPort int, sourceItems string) (slb.AddListenerWhiteListItemResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
@@ -185,8 +185,8 @@ func AddListenerWhiteListItem(loadBalancerId string, listenerPort int, sourceIte
 	return cli.Listener.AddListenerWhiteListItem(params)
 }
 
-func RemoveListenerWhiteListItem(loadBalancerId string, listenerPort int, sourceItems string) (slb.RemoveListenerWhiteListItemResponse, error) {
-	cli := GetSlbClient()
+func RemoveListenerWhiteListItem(keyId string, loadBalancerId string, listenerPort int, sourceItems string) (slb.RemoveListenerWhiteListItemResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
@@ -194,8 +194,8 @@ func RemoveListenerWhiteListItem(loadBalancerId string, listenerPort int, source
 	return cli.Listener.RemoveListenerWhiteListItem(params)
 }
 
-func DescribeListenerAccessControlAttribute(loadBalancerId string, listenerPort int) (slb.DescribeListenerAccessControlAttributeResponse, error) {
-	cli := GetSlbClient()
+func DescribeListenerAccessControlAttribute(keyId string, loadBalancerId string, listenerPort int) (slb.DescribeListenerAccessControlAttributeResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
@@ -203,7 +203,7 @@ func DescribeListenerAccessControlAttribute(loadBalancerId string, listenerPort 
 }
 
 func SetLoadBalancerHTTPListenerAttribute(listener models.Listener) (slb.SetLoadBalancerHTTPListenerAttributeResponse, error) {
-	cli := GetSlbClient()
+	cli := GetSlbClientByKeyId(listener.KeyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = listener.LoadBalancerId
 	params["ListenerPort"] = listener.ListenerPort
@@ -235,7 +235,7 @@ func SetLoadBalancerHTTPListenerAttribute(listener models.Listener) (slb.SetLoad
 }
 
 func SetLoadBalancerHTTPSListenerAttribute(listener models.Listener) (slb.SetLoadBalancerHTTPSListenerAttributeResponse, error) {
-	cli := GetSlbClient()
+	cli := GetSlbClientByKeyId(listener.KeyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = listener.LoadBalancerId
 	params["ListenerPort"] = listener.ListenerPort
@@ -268,7 +268,7 @@ func SetLoadBalancerHTTPSListenerAttribute(listener models.Listener) (slb.SetLoa
 }
 
 func SetLoadBalancerTCPListenerAttribute(listener models.Listener) (slb.SetLoadBalancerTCPListenerAttributeResponse, error) {
-	cli := GetSlbClient()
+	cli := GetSlbClientByKeyId(listener.KeyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = listener.LoadBalancerId
 	params["ListenerPort"] = listener.ListenerPort
@@ -292,7 +292,7 @@ func SetLoadBalancerTCPListenerAttribute(listener models.Listener) (slb.SetLoadB
 }
 
 func SetLoadBalancerUDPListenerAttribute(listener models.Listener) (slb.SetLoadBalancerUDPListenerAttributeResponse, error) {
-	cli := GetSlbClient()
+	cli := GetSlbClientByKeyId(listener.KeyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = listener.LoadBalancerId
 	params["ListenerPort"] = listener.ListenerPort
@@ -315,32 +315,32 @@ func SetLoadBalancerUDPListenerAttribute(listener models.Listener) (slb.SetLoadB
 	return cli.Listener.SetLoadBalancerUDPListenerAttribute(params)
 }
 
-func DescribeLoadBalancerHTTPListenerAttribute(loadBalancerId string, listenerPort int) (slb.DescribeLoadBalancerHTTPListenerAttributeResponse, error) {
-	cli := GetSlbClient()
+func DescribeLoadBalancerHTTPListenerAttribute(loadBalancerId string, listenerPort int, keyId string) (slb.DescribeLoadBalancerHTTPListenerAttributeResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
 	return cli.Listener.DescribeLoadBalancerHTTPListenerAttribute(params)
 }
 
-func DescribeLoadBalancerHTTPSListenerAttribute(loadBalancerId string, listenerPort int) (slb.DescribeLoadBalancerHTTPSListenerAttributeResponse, error) {
-	cli := GetSlbClient()
+func DescribeLoadBalancerHTTPSListenerAttribute(loadBalancerId string, listenerPort int, keyId string) (slb.DescribeLoadBalancerHTTPSListenerAttributeResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
 	return cli.Listener.DescribeLoadBalancerHTTPSListenerAttribute(params)
 }
 
-func DescribeLoadBalancerTCPListenerAttribute(loadBalancerId string, listenerPort int) (slb.DescribeLoadBalancerTCPListenerAttributeResponse, error) {
-	cli := GetSlbClient()
+func DescribeLoadBalancerTCPListenerAttribute(loadBalancerId string, listenerPort int, keyId string) (slb.DescribeLoadBalancerTCPListenerAttributeResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort
 	return cli.Listener.DescribeLoadBalancerTCPListenerAttribute(params)
 }
 
-func DescribeLoadBalancerUDPListenerAttribute(loadBalancerId string, listenerPort int) (slb.DescribeLoadBalancerUDPListenerAttributeResponse, error) {
-	cli := GetSlbClient()
+func DescribeLoadBalancerUDPListenerAttribute(loadBalancerId string, listenerPort int, keyId string) (slb.DescribeLoadBalancerUDPListenerAttributeResponse, error) {
+	cli := GetSlbClientByKeyId(keyId)
 	params := make(map[string]interface{})
 	params["LoadBalancerId"] = loadBalancerId
 	params["ListenerPort"] = listenerPort

--- a/ui/api/for_cloud/cluster.php
+++ b/ui/api/for_cloud/cluster.php
@@ -27,214 +27,253 @@ include_once('../../include/cloud.php');
 //cloud类提供了curl方法的调用
 $thisClass = $cloud;
 
-class myself{
-  private $module = 'cluster';
+class myself
+{
+    private $module = 'cluster';
 
-  function getList($myUser = '', $param = array(), $id=''){
-    global $thisClass;
-    $ret=array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
-    if($strList = $thisClass->get($myUser, $this->module, 'GET', $param ,$id)){
-      $arrList = json_decode($strList,true);
-      if(isset($arrList['code']) && $arrList['code'] == 0 && isset($arrList['content'])){
-        $ret = array(
-          'code' => 0,
-          'msg' => 'success',
-          'title' => array(
-            '#',
-            '名称',
-            '使用云',
-            '配额余量',
-            '创建时间',
-            '#',
-          ),
-          'content' => array(),
-        );
-        $i=0;
-        foreach($arrList['content'] as $k => $v){
+    function getList($myUser = '', $param = array(), $id = '')
+    {
+        global $thisClass;
+        $ret = array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
+        if ($strList = $thisClass->get($myUser, $this->module, 'GET', $param, $id)) {
+            $arrList = json_decode($strList, true);
+            if (isset($arrList['code']) && $arrList['code'] == 0 && isset($arrList['content'])) {
+                $ret = array(
+                    'code' => 0,
+                    'msg' => 'success',
+                    'title' => array(
+                        '#',
+                        '名称',
+                        '使用云',
+                        '云账号KeyID',
+                        '配额余量',
+                        '创建时间',
+                        '#',
+                    ),
+                    'content' => array(),
+                );
+                $i = 0;
+                foreach ($arrList['content'] as $k => $v) {
 
-          //机型模板不再对外显示物理机
-          if($v['Provider'] == 'phydev') continue;
+                    //机型模板不再对外显示物理机
+                    if ($v['Provider'] == 'phydev') continue;
 
-          $i++;
-          $tArr = array();
-          $tArr['i'] = $i;
-          foreach($v as $key => $value){
-            $tArr[$key] = $value;
-          }
-          $ret['content'][] = $tArr;
+                    $i++;
+                    $tArr = array();
+                    $tArr['i'] = $i;
+                    foreach ($v as $key => $value) {
+                        $tArr[$key] = $value;
+                    }
+                    $ret['content'][] = $tArr;
+                }
+                $ret['count'] = (isset($arrList['totalCount'])) ? $arrList['totalCount'] : 0;
+                if ($i > $ret['count']) $ret['count'] = count($ret['content']);
+                $ret['pageCount'] = ($ret['count'] > 0 && isset($arrList['pageSize']) && $arrList['pageSize'] > 0) ? ceil($ret['count'] / $arrList['pageSize']) : 1;
+                $ret['page'] = (isset($arrList['pageNumber'])) ? $arrList['pageNumber'] : 1;
+            } else {
+                $ret['code'] = 1;
+                $arrList = json_decode($strList, true);
+                $ret['msg'] = (isset($arrList['msg'])) ? $arrList['msg'] : $strList;
+                $ret['remote'] = $strList;
+            }
         }
-        $ret['count'] = (isset($arrList['totalCount'])) ? $arrList['totalCount'] : 0;
-        if($i>$ret['count']) $ret['count']=count($ret['content']);
-        $ret['pageCount'] = ($ret['count']>0&&isset($arrList['pageSize'])&&$arrList['pageSize']>0) ? ceil($ret['count']/$arrList['pageSize']) : 1;
-        $ret['page'] = (isset($arrList['pageNumber'])) ? $arrList['pageNumber'] : 1;
-      }else{
-        $ret['code'] = 1;
-        $arrList = json_decode($strList,true);
-        $ret['msg'] = (isset($arrList['msg']))?$arrList['msg']:$strList;
-        $ret['remote'] = $strList;
-      }
+        $ret['ret'] = $strList;
+        return $ret;
     }
-    $ret['ret'] = $strList;
-    return $ret;
-  }
 
-  function getMachines($myUser = '', $namespace = '', $method = 'GET', $id = ''){
-      global $thisClass;
-      $ret=array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
-      if($strList = $thisClass->get($myUser, $this->module.'/'.$namespace, $method, '' ,$id)){
-          $arrList = json_decode($strList,true);
-          if(isset($arrList['code']) && $arrList['code'] == 0 && isset($arrList['content'])){
-              $ret = array(
-                  'code' => 0,
-                  'msg' => 'success',
-                  'content' => array(),
-              );
-              $ret['content']=$arrList['content'];
-          }else{
-              $ret['code'] = 1;
-              $arrList = json_decode($strList,true);
-              $ret['msg'] = (isset($arrList['msg']))?$arrList['msg']:$strList;
-              $ret['remote'] = $strList;
-          }
-      }
-      $ret['ret'] = $strList;
-      return $ret;
-  }
-
-  function getInfo($myUser = '', $idx = ''){
-    global $thisClass;
-    $ret=array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
-    if($strList = $thisClass->get($myUser, $this->module, 'GET', '', $idx)){
-      $arrList = json_decode($strList,true);
-      if(isset($arrList['code']) && $arrList['code'] == 0 && isset($arrList['content'])){
-        $ret = array(
-          'code' => 0,
-          'msg' => 'success',
-          'content' => array(),
-        );
-        $ret['content']=$arrList['content'];
-      }else{
-        $ret['code'] = 1;
-        $arrList = json_decode($strList,true);
-        $ret['msg'] = (isset($arrList['msg']))?$arrList['msg']:$strList;
-        $ret['remote'] = $strList;
-      }
+    function getMachines($myUser = '', $namespace = '', $method = 'GET', $id = '')
+    {
+        global $thisClass;
+        $ret = array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
+        if ($strList = $thisClass->get($myUser, $this->module . '/' . $namespace, $method, '', $id)) {
+            $arrList = json_decode($strList, true);
+            if (isset($arrList['code']) && $arrList['code'] == 0 && isset($arrList['content'])) {
+                $ret = array(
+                    'code' => 0,
+                    'msg' => 'success',
+                    'content' => array(),
+                );
+                $ret['content'] = $arrList['content'];
+            } else {
+                $ret['code'] = 1;
+                $arrList = json_decode($strList, true);
+                $ret['msg'] = (isset($arrList['msg'])) ? $arrList['msg'] : $strList;
+                $ret['remote'] = $strList;
+            }
+        }
+        $ret['ret'] = $strList;
+        return $ret;
     }
-    $ret['ret'] = $strList;
-    return $ret;
-  }
 
-  function update($myUser = '', $method = 'POST', $param = array(), $id = ''){
+    function getInfo($myUser = '', $idx = '')
+    {
+        global $thisClass;
+        $ret = array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
+        if ($strList = $thisClass->get($myUser, $this->module, 'GET', '', $idx)) {
+            $arrList = json_decode($strList, true);
+            if (isset($arrList['code']) && $arrList['code'] == 0 && isset($arrList['content'])) {
+                $ret = array(
+                    'code' => 0,
+                    'msg' => 'success',
+                    'content' => array(),
+                );
+                $ret['content'] = $arrList['content'];
+            } else {
+                $ret['code'] = 1;
+                $arrList = json_decode($strList, true);
+                $ret['msg'] = (isset($arrList['msg'])) ? $arrList['msg'] : $strList;
+                $ret['remote'] = $strList;
+            }
+        }
+        $ret['ret'] = $strList;
+        return $ret;
+    }
+
+    function update($myUser = '', $method = 'POST', $param = array(), $id = '')
+    {
+        global $thisClass;
+        $ret = array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
+        if ($param) {
+            if ($strList = $thisClass->get($myUser, $this->module, $method, $param, $id)) {
+                $arrList = json_decode($strList, true);
+                if (isset($arrList['code']) && $arrList['code'] == 0) {
+                    $ret = array(
+                        'code' => 0,
+                        'msg' => 'success',
+                    );
+                } else {
+                    $ret['code'] = 1;
+                    $arrList = json_decode($strList, true);
+                    $ret['msg'] = (isset($arrList['msg'])) ? $arrList['msg'] : $strList;
+                    $ret['remote'] = $strList;
+                }
+            }
+            $ret['ret'] = $strList;
+        }
+        return $ret;
+    }
+
+  function getCloudAccount($vendorType)
+  {
     global $thisClass;
     $ret = array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
-    if($param){
-      if($strList = $thisClass->get($myUser, $this->module, $method, $param , $id)){
-        $arrList = json_decode($strList,true);
-        if(isset($arrList['code']) && $arrList['code'] == 0){
-          $ret = array(
+    if ($strList = $thisClass->get('', $this->module . '/list_account/' . $vendorType, 'GET', '', '')) {
+      $arrList = json_decode($strList, true);
+      if (isset($arrList['code']) && $arrList['code'] == 0 && isset($arrList['content'])) {
+        $ret = array(
             'code' => 0,
             'msg' => 'success',
-          );
-        }else{
-          $ret['code'] = 1;
-          $arrList = json_decode($strList,true);
-          $ret['msg'] = (isset($arrList['msg']))?$arrList['msg']:$strList;
-          $ret['remote'] = $strList;
-        }
+            'content' => array(),
+        );
+        $ret['content'] = $arrList['content'];
+      } else {
+        $ret['code'] = 1;
+        $arrList = json_decode($strList, true);
+        $ret['msg'] = (isset($arrList['msg'])) ? $arrList['msg'] : $strList;
+        $ret['remote'] = $strList;
       }
-      $ret['ret'] = $strList;
     }
+    $ret['ret'] = $strList;
     return $ret;
   }
-
 }
-$mySelf=new myself();
+
+$mySelf = new myself();
 
 /*权限检查*/
 $pageForSuper = false;//当前页面是否需要管理员权限
-$hasLimit = ($pageForSuper)?isSuper($myUser):true;
-$myAction = (isset($_POST['action'])&&!empty($_POST['action']))?trim($_POST['action']):((isset($_GET['action'])&&!empty($_GET['action']))?trim($_GET['action']):'');
-$myPage = (isset($_POST['page'])&&intval($_POST['page'])>0)?intval($_POST['page']):((isset($_GET['page'])&&intval($_GET['page'])>0)?intval($_GET['page']):1);
-$myPageSize = (isset($_POST['pagesize'])&&intval($_POST['pagesize'])>0)?intval($_POST['pagesize']):((isset($_GET['pagesize'])&&intval($_GET['pagesize'])>0)?intval($_GET['pagesize']):$myPageSize);
+$hasLimit = ($pageForSuper) ? isSuper($myUser) : true;
+$myAction = (isset($_POST['action']) && !empty($_POST['action'])) ? trim($_POST['action']) : ((isset($_GET['action']) && !empty($_GET['action'])) ? trim($_GET['action']) : '');
+$myPage = (isset($_POST['page']) && intval($_POST['page']) > 0) ? intval($_POST['page']) : ((isset($_GET['page']) && intval($_GET['page']) > 0) ? intval($_GET['page']) : 1);
+$myPageSize = (isset($_POST['pagesize']) && intval($_POST['pagesize']) > 0) ? intval($_POST['pagesize']) : ((isset($_GET['pagesize']) && intval($_GET['pagesize']) > 0) ? intval($_GET['pagesize']) : $myPageSize);
 
-$fOrg=(isset($_POST['fOrg'])&&!empty($_POST['fOrg']))?trim($_POST['fOrg']):((isset($_GET['fOrg'])&&!empty($_GET['fOrg']))?trim($_GET['fOrg']):'');
-$fIdx=(isset($_POST['fIdx'])&&!empty($_POST['fIdx']))?trim($_POST['fIdx']):((isset($_GET['fIdx'])&&!empty($_GET['fIdx']))?trim($_GET['fIdx']):'');
+$fOrg = (isset($_POST['fOrg']) && !empty($_POST['fOrg'])) ? trim($_POST['fOrg']) : ((isset($_GET['fOrg']) && !empty($_GET['fOrg'])) ? trim($_GET['fOrg']) : '');
+$fIdx = (isset($_POST['fIdx']) && !empty($_POST['fIdx'])) ? trim($_POST['fIdx']) : ((isset($_GET['fIdx']) && !empty($_GET['fIdx'])) ? trim($_GET['fIdx']) : '');
 
-$myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
-$arrJson=($myJson)?json_decode($myJson,true):array();
+$myJson = (isset($_POST['data']) && !empty($_POST['data'])) ? trim($_POST['data']) : ((isset($_GET['data']) && !empty($_GET['data'])) ? trim($_GET['data']) : '');
+$arrJson = ($myJson) ? json_decode($myJson, true) : array();
 
 //记录操作日志
 $logFlag = true;
 $logDesc = 'FAILED';
-$arrRecodeLog=array(
-  't_time' => date('Y-m-d H:i:s'),
-  't_user' => $myUser,
-  't_module' => '类型管理',
-  't_action' => '',
-  't_desc' => 'Resource:' . $_SERVER['REMOTE_ADDR'] . '.',
-  't_code' => '传入：' . $myJson . "\n\n",
+$arrRecodeLog = array(
+    't_time' => date('Y-m-d H:i:s'),
+    't_user' => $myUser,
+    't_module' => '类型管理',
+    't_action' => '',
+    't_desc' => 'Resource:' . $_SERVER['REMOTE_ADDR'] . '.',
+    't_code' => '传入：' . $myJson . "\n\n",
 );
 //返回
 $retArr = array(
-  'code' => 1,
-  'action' => $myAction,
+    'code' => 1,
+    'action' => $myAction,
 );
-if($hasLimit){
-  $retArr['msg'] = 'Param Error!';
-  switch($myAction){
-    case 'list':
-      $logFlag = false;//本操作不记录日志
-      $arrJson = array(
-        'page' => $myPage,
-        'pagesize' => $myPageSize,
-      );
-      $retArr = $mySelf->getList($myUser, $arrJson);
-      $retArr['page'] = $myPage;
-      $retArr['pageSize'] = $myPageSize;
-      if(!isset($retArr['pageCount']) || $retArr['page'] > $retArr['pageCount']) $retArr['page'] = 1;
-      break;
-    case 'info':
-      $logFlag = false;//本操作不记录日志
-      $retArr = $mySelf->getInfo($myUser,$fIdx);
-      break;
-    case 'insert':
-      if($myStatus > 0){$retArr['msg'] = 'Permission Denied!'; }
-      $arrRecodeLog['t_action'] = '创建';
-      if(isset($arrJson) && !empty($arrJson)){
-        $retArr = $mySelf->update($myUser,'POST', $arrJson);
-        $logDesc = (isset($retArr['code']) && $retArr['code'] == 0) ? 'SUCCESS' : 'FAILED';
-      }
-      break;
-    case 'delete':
-      if($myStatus > 0){ $retArr['msg'] = 'Permission Denied!'; break; }
-      $arrRecodeLog['t_action'] = '删除';
-      if(isset($arrJson) && !empty($arrJson)){
-        $retArr=$mySelf->update($myUser, 'DELETE', $arrJson, $arrJson['id']);
-        $logDesc = (isset($retArr['code']) && $retArr['code'] == 0) ? 'SUCCESS' : 'FAILED';
-      }
-      break;
-    case 'machine':
-        $logFlag = false;//本操作不记录日志
-        if(isset($arrJson) && !empty($arrJson)){
-            $retArr=$mySelf->getMachines($myUser, $arrJson["action"],'GET', $arrJson["hour"]);
+if ($hasLimit) {
+    $retArr['msg'] = 'Param Error!';
+    switch ($myAction) {
+        case 'list':
+            $logFlag = false;//本操作不记录日志
+            $arrJson = array(
+                'page' => $myPage,
+                'pagesize' => $myPageSize,
+            );
+            $retArr = $mySelf->getList($myUser, $arrJson);
+            $retArr['page'] = $myPage;
+            $retArr['pageSize'] = $myPageSize;
+            if (!isset($retArr['pageCount']) || $retArr['page'] > $retArr['pageCount']) $retArr['page'] = 1;
+            break;
+        case 'info':
+            $logFlag = false;//本操作不记录日志
+            $retArr = $mySelf->getInfo($myUser, $fIdx);
+            break;
+        case 'insert':
+            if ($myStatus > 0) {
+                $retArr['msg'] = 'Permission Denied!';
+            }
+            $arrRecodeLog['t_action'] = '创建';
+            if (isset($arrJson) && !empty($arrJson)) {
+                $retArr = $mySelf->update($myUser, 'POST', $arrJson);
+                $logDesc = (isset($retArr['code']) && $retArr['code'] == 0) ? 'SUCCESS' : 'FAILED';
+            }
+            break;
+        case 'delete':
+            if ($myStatus > 0) {
+                $retArr['msg'] = 'Permission Denied!';
+                break;
+            }
+            $arrRecodeLog['t_action'] = '删除';
+            if (isset($arrJson) && !empty($arrJson)) {
+                $retArr = $mySelf->update($myUser, 'DELETE', $arrJson, $arrJson['id']);
+                $logDesc = (isset($retArr['code']) && $retArr['code'] == 0) ? 'SUCCESS' : 'FAILED';
+            }
+            break;
+        case 'machine':
+            $logFlag = false;//本操作不记录日志
+            if (isset($arrJson) && !empty($arrJson)) {
+                $retArr = $mySelf->getMachines($myUser, $arrJson["action"], 'GET', $arrJson["hour"]);
+                $logDesc = (isset($retArr['code']) && $retArr['code'] == 0) ? 'SUCCESS' : 'FAILED';
+            }
+        case 'getaccount':
+            $logFlag = false; //本操作不记录日志
+            $retArr = $mySelf->getCloudAccount($_REQUEST["vendor_type"]);
             $logDesc = (isset($retArr['code']) && $retArr['code'] == 0) ? 'SUCCESS' : 'FAILED';
-        }
-      break;
-  }
-}else{
-  $retArr['msg'] = 'Permission Denied!';
+            break;
+    }
+} else {
+    $retArr['msg'] = 'Permission Denied!';
 }
 //记录日志
-if($logFlag){
-  $arrRecodeLog['t_desc'] = $logDesc.', '.$arrRecodeLog['t_desc'];
-  $arrRecodeLog['t_code'] .= '外部接口传入：' . json_encode($arrJson,JSON_UNESCAPED_UNICODE) . "\n\n";
-  $arrRecodeLog['t_code'] .= '外部接口返回：' . str_replace(array("\n", "\r"), '', $retArr['ret']) . "\n\n";
-  $arrRecodeLog['t_code'] .= '返回：' . json_encode($retArr,JSON_UNESCAPED_UNICODE);
-  if(empty($arrRecodeLog['t_action'])) $arrRecodeLog['t_action'] = $myAction;
-  logRecord($arrRecodeLog);
+if ($logFlag) {
+    $arrRecodeLog['t_desc'] = $logDesc . ', ' . $arrRecodeLog['t_desc'];
+    $arrRecodeLog['t_code'] .= '外部接口传入：' . json_encode($arrJson, JSON_UNESCAPED_UNICODE) . "\n\n";
+    $arrRecodeLog['t_code'] .= '外部接口返回：' . str_replace(array("\n", "\r"), '', $retArr['ret']) . "\n\n";
+    $arrRecodeLog['t_code'] .= '返回：' . json_encode($retArr, JSON_UNESCAPED_UNICODE);
+    if (empty($arrRecodeLog['t_action'])) $arrRecodeLog['t_action'] = $myAction;
+    logRecord($arrRecodeLog);
 }
 //返回结果
-if(isset($retArr['action']) && !empty($retArr['action'])) $retArr['action'] = $myAction;
-if(isset($retArr['ret'])) unset($retArr['ret']);
+if (isset($retArr['action']) && !empty($retArr['action'])) $retArr['action'] = $myAction;
+if (isset($retArr['ret'])) unset($retArr['ret']);
 echo json_encode($retArr, JSON_UNESCAPED_UNICODE);
 ?>

--- a/ui/api/for_cloud/ecs_type.php
+++ b/ui/api/for_cloud/ecs_type.php
@@ -84,6 +84,8 @@ $myPageSize = (isset($_POST['pagesize'])&&intval($_POST['pagesize'])>0)?intval($
 $fProvider=(isset($_POST['fProvider'])&&!empty($_POST['fProvider']))?trim($_POST['fProvider']):((isset($_GET['fProvider'])&&!empty($_GET['fProvider']))?trim($_GET['fProvider']):'aliyun');
 $fIdx=(isset($_POST['fIdx'])&&!empty($_POST['fIdx']))?trim($_POST['fIdx']):((isset($_GET['fIdx'])&&!empty($_GET['fIdx']))?trim($_GET['fIdx']):'');
 
+$fKeyId=(isset($_POST['fKeyId'])&&!empty($_POST['fKeyId']))?trim($_POST['fKeyId']):((isset($_GET['fKeyId'])&&!empty($_GET['fKeyId']))?trim($_GET['fKeyId']):'');
+
 $myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
 $arrJson=($myJson)?json_decode($myJson,true):array();
 
@@ -111,6 +113,7 @@ if($hasLimit){
       $arrJson = array(
         'page' => $myPage,
         'pagesize' => $myPageSize,
+        'keyId' => $fKeyId,
       );
       $retArr = $mySelf->getList($myUser, $fProvider, $arrJson);
       $retArr['page'] = $myPage;

--- a/ui/api/for_cloud/image.php
+++ b/ui/api/for_cloud/image.php
@@ -80,6 +80,8 @@ $myPageSize = (isset($_POST['pagesize'])&&intval($_POST['pagesize'])>0)?intval($
 $fProvider=(isset($_POST['fProvider'])&&!empty($_POST['fProvider']))?trim($_POST['fProvider']):((isset($_GET['fProvider'])&&!empty($_GET['fProvider']))?trim($_GET['fProvider']):'aliyun');
 $fIdx=(isset($_POST['fIdx'])&&!empty($_POST['fIdx']))?trim($_POST['fIdx']):((isset($_GET['fIdx'])&&!empty($_GET['fIdx']))?trim($_GET['fIdx']):'');
 
+$fKeyId=(isset($_POST['fKeyId'])&&!empty($_POST['fKeyId']))?trim($_POST['fKeyId']):((isset($_GET['fKeyId'])&&!empty($_GET['fKeyId']))?trim($_GET['fKeyId']):'');
+
 $myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
 $arrJson=($myJson)?json_decode($myJson,true):array();
 
@@ -107,6 +109,7 @@ if($hasLimit){
       $arrJson = array(
         'page' => $myPage,
         'pagesize' => $myPageSize,
+        'keyId' => $fKeyId,
       );
       $retArr = $mySelf->getList($myUser, $fProvider, $arrJson, $fIdx);
       $retArr['page'] = $myPage;

--- a/ui/api/for_cloud/security_group.php
+++ b/ui/api/for_cloud/security_group.php
@@ -84,6 +84,8 @@ $fIdx=(isset($_POST['fIdx'])&&!empty($_POST['fIdx']))?trim($_POST['fIdx']):((iss
 $myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
 $arrJson=($myJson)?json_decode($myJson,true):array();
 
+$fKeyId=(isset($_POST['fKeyId'])&&!empty($_POST['fKeyId']))?trim($_POST['fKeyId']):((isset($_GET['fKeyId'])&&!empty($_GET['fKeyId']))?trim($_GET['fKeyId']):'');
+
 //记录操作日志
 $logFlag = true;
 $logDesc = 'FAILED';
@@ -109,6 +111,7 @@ if($hasLimit){
         'page' => $myPage,
         'pagesize' => $myPageSize,
         'VpcId' => $fIdx,
+        'keyId' => $fKeyId,
       );
       $retArr = $mySelf->getList($myUser, $fProvider, $arrJson , $fRegion);
       $retArr['page'] = $myPage;

--- a/ui/api/for_cloud/slb.php
+++ b/ui/api/for_cloud/slb.php
@@ -78,10 +78,19 @@ class myself{
     return $ret;
   }
 
-  function getInfo($myUser = '', $idx = ''){
+  function getInfo($myUser = '', $idx = '', $fKeyId = ''){
     global $thisClass;
+
+    if(!empty($fKeyId)) {
+      $data = array(
+          'keyId' => $fKeyId,
+      );
+    } else {
+      $data = '';
+    }
+
     $ret=array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
-    if($strList = $thisClass->get($myUser, $this->module.'/'.$this->sub_module, 'GET', '', $idx)){
+    if($strList = $thisClass->get($myUser, $this->module.'/'.$this->sub_module, 'GET', $data, $idx)){
       $arrList = json_decode($strList,true);
       if(isset($arrList['code']) && $arrList['code'] == 0 && isset($arrList['content'])){
         $ret = array(
@@ -183,6 +192,9 @@ $fIdx=(isset($_POST['fIdx'])&&!empty($_POST['fIdx']))?trim($_POST['fIdx']):((iss
 $myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
 $arrJson=($myJson)?json_decode($myJson,true):array();
 
+$fKeyId=(isset($_POST['fKeyId'])&&!empty($_POST['fKeyId']))?trim($_POST['fKeyId']):((isset($_GET['fKeyId'])&&!empty($_GET['fKeyId']))?trim($_GET['fKeyId']):'');
+$arrJson['keyId'] = $fKeyId;
+
 //记录操作日志
 $logFlag = true;
 $logDesc = 'FAILED';
@@ -207,6 +219,7 @@ if($hasLimit){
       $arrJson = array(
         'page' => $myPage,
         'pageSize' => $myPageSize,
+        'keyId' => $fKeyId,
       );
       $retArr = $mySelf->getList($myUser, 'list', $arrJson , $fRegion);
       $retArr['page'] = $myPage;
@@ -215,7 +228,7 @@ if($hasLimit){
       break;
     case 'info':
       $logFlag = false;//本操作不记录日志
-      $retArr = $mySelf->getInfo($myUser,$fIdx);
+      $retArr = $mySelf->getInfo($myUser,$fIdx,$fKeyId);
       break;
     case 'insert':
       if($myStatus > 0){ $retArr['msg'] = 'Permission Denied!'; break; }

--- a/ui/api/for_cloud/slb_backend.php
+++ b/ui/api/for_cloud/slb_backend.php
@@ -70,7 +70,8 @@ class myself{
     global $thisClass;
     $ret = array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
     if($param){
-      if($strList = $thisClass->get($myUser, $this->module.'/'.$this->sub_module, $method, $param , $id)){
+      $url = $this->module.'/'.$this->sub_module;
+      if($strList = $thisClass->get($myUser, $url, $method, $param , $id)){
         $arrList = json_decode($strList,true);
         if(isset($arrList['code']) && $arrList['code'] == 0){
           $ret = array(
@@ -127,6 +128,8 @@ $fIdx=(isset($_POST['fIdx'])&&!empty($_POST['fIdx']))?trim($_POST['fIdx']):((iss
 $myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
 $arrJson=($myJson)?json_decode($myJson,true):array();
 
+$fKeyId=(isset($_POST['fKeyId'])&&!empty($_POST['fKeyId']))?trim($_POST['fKeyId']):((isset($_GET['fKeyId'])&&!empty($_GET['fKeyId']))?trim($_GET['fKeyId']):'');
+
 //记录操作日志
 $logFlag = true;
 $logDesc = 'FAILED';
@@ -151,6 +154,7 @@ if($hasLimit){
       $arrJson = array(
         'page' => $myPage,
         'pagesize' => $myPageSize,
+        'keyId' => $fKeyId,
       );
       $retArr = $mySelf->getList($myUser, 'healthstatus', $arrJson , $fIdx);
       $retArr['page'] = $myPage;

--- a/ui/api/for_cloud/slb_listener.php
+++ b/ui/api/for_cloud/slb_listener.php
@@ -116,6 +116,9 @@ $fPort=(isset($_POST['fPort'])&&!empty($_POST['fPort']))?trim($_POST['fPort']):(
 $myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
 $arrJson=($myJson)?json_decode($myJson,true):array();
 
+$fKeyId=(isset($_POST['fKeyId'])&&!empty($_POST['fKeyId']))?trim($_POST['fKeyId']):((isset($_GET['fKeyId'])&&!empty($_GET['fKeyId']))?trim($_GET['fKeyId']):'');
+$arrJson['keyId'] = $fKeyId;
+
 //记录操作日志
 $logFlag = true;
 $logDesc = 'FAILED';
@@ -141,6 +144,7 @@ if($hasLimit){
         'LoadBalancerId' => $fIdx,
         'ListenerPort' => $fPort,
         'Protocol' => $fProtocol,
+        'keyId' => $fKeyId,
       );
       $retArr = $mySelf->getInfo($myUser,$param);
       break;

--- a/ui/api/for_cloud/subnet.php
+++ b/ui/api/for_cloud/subnet.php
@@ -81,6 +81,8 @@ $fProvider=(isset($_POST['fProvider'])&&!empty($_POST['fProvider']))?trim($_POST
 $fZone=(isset($_POST['fZone'])&&!empty($_POST['fZone']))?trim($_POST['fZone']):((isset($_GET['fZone'])&&!empty($_GET['fZone']))?trim($_GET['fZone']):'');
 $fIdx=(isset($_POST['fIdx'])&&!empty($_POST['fIdx']))?trim($_POST['fIdx']):((isset($_GET['fIdx'])&&!empty($_GET['fIdx']))?trim($_GET['fIdx']):'');
 
+$fKeyId=(isset($_POST['fKeyId'])&&!empty($_POST['fKeyId']))?trim($_POST['fKeyId']):((isset($_GET['fKeyId'])&&!empty($_GET['fKeyId']))?trim($_GET['fKeyId']):'');
+
 $myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
 $arrJson=($myJson)?json_decode($myJson,true):array();
 
@@ -108,6 +110,7 @@ if($hasLimit){
       $arrJson = array(
         'page' => $myPage,
         'pagesize' => $myPageSize,
+        'keyId' => $fKeyId,
       );
       $retArr = $mySelf->getList($myUser, $fProvider, $arrJson , $fZone.'/'.$fIdx);
       $retArr['page'] = $myPage;

--- a/ui/api/for_cloud/vpc.php
+++ b/ui/api/for_cloud/vpc.php
@@ -80,6 +80,8 @@ $myPageSize = (isset($_POST['pagesize'])&&intval($_POST['pagesize'])>0)?intval($
 $fProvider=(isset($_POST['fProvider'])&&!empty($_POST['fProvider']))?trim($_POST['fProvider']):((isset($_GET['fProvider'])&&!empty($_GET['fProvider']))?trim($_GET['fProvider']):'aliyun');
 $fIdx=(isset($_POST['fIdx'])&&!empty($_POST['fIdx']))?trim($_POST['fIdx']):((isset($_GET['fIdx'])&&!empty($_GET['fIdx']))?trim($_GET['fIdx']):'');
 
+$fKeyId=(isset($_POST['fKeyId'])&&!empty($_POST['fKeyId']))?trim($_POST['fKeyId']):((isset($_GET['fKeyId'])&&!empty($_GET['fKeyId']))?trim($_GET['fKeyId']):'');
+
 $myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
 $arrJson=($myJson)?json_decode($myJson,true):array();
 
@@ -107,6 +109,7 @@ if($hasLimit){
       $arrJson = array(
         'page' => $myPage,
         'pagesize' => $myPageSize,
+        'keyId' => $fKeyId,
       );
       $retArr = $mySelf->getList($myUser, $fProvider, $arrJson , $fIdx);
       $retArr['page'] = $myPage;

--- a/ui/api/for_cloud/zone.php
+++ b/ui/api/for_cloud/zone.php
@@ -30,7 +30,7 @@ class myself{
   private $module = 'instance';
   private $sub_module = 'zones';
 
-  function getList($myUser = '', $type='aliyun', $param = array(), $id=''){
+  function getList($myUser = '', $type='aliyun', $param = array(), $id='', $keyId = ''){
     global $thisClass;
     $ret=array('code' => 1, 'msg' => 'Illegal Request', 'ret' => '');
     if($strList = $thisClass->get($myUser, $this->module.'/'.$this->sub_module.'/'.$type, 'GET', $param ,$id)){
@@ -79,6 +79,7 @@ $myPageSize = (isset($_POST['pagesize'])&&intval($_POST['pagesize'])>0)?intval($
 
 $fProvider=(isset($_POST['fProvider'])&&!empty($_POST['fProvider']))?trim($_POST['fProvider']):((isset($_GET['fProvider'])&&!empty($_GET['fProvider']))?trim($_GET['fProvider']):'aliyun');
 $fIdx=(isset($_POST['fIdx'])&&!empty($_POST['fIdx']))?trim($_POST['fIdx']):((isset($_GET['fIdx'])&&!empty($_GET['fIdx']))?trim($_GET['fIdx']):'');
+$fKeyId=(isset($_POST['fKeyId'])&&!empty($_POST['fKeyId']))?trim($_POST['fKeyId']):((isset($_GET['fKeyId'])&&!empty($_GET['fKeyId']))?trim($_GET['fKeyId']):'');
 
 $myJson=(isset($_POST['data'])&&!empty($_POST['data']))?trim($_POST['data']):((isset($_GET['data'])&&!empty($_GET['data']))?trim($_GET['data']):'');
 $arrJson=($myJson)?json_decode($myJson,true):array();
@@ -107,6 +108,7 @@ if($hasLimit){
       $arrJson = array(
         'page' => $myPage,
         'pagesize' => $myPageSize,
+        'keyId' => $fKeyId,
       );
       $retArr = $mySelf->getList($myUser, $fProvider, $arrJson , $fIdx);
       $retArr['page'] = $myPage;

--- a/ui/for_cloud/edit_cluster.php
+++ b/ui/for_cloud/edit_cluster.php
@@ -47,6 +47,14 @@
 
                     </div>
                 </div>
+                <div class="form-group" style="display: none;" id="select-cloud-account">
+                    <label for="Account" class="col-sm-2 control-label">云账号</label>
+                    <div class="col-sm-10">
+                        <select class="form-control" id="Account" name="Account">
+                            <option value="default">请选择</option>
+                        </select>
+                    </div>
+                </div>
             </div>
 
             <div id="step-2" class="content" style="display: none;">

--- a/ui/for_hubble/edit_slb.php
+++ b/ui/for_hubble/edit_slb.php
@@ -37,6 +37,19 @@
               </select>
             </div>
           </div>
+        <div class="form-group">
+            <label for="LoadBalancerSpec" class="col-sm-2 control-label">规格</label>
+            <div class="col-sm-10">
+                <select class="form-control" id="LoadBalancerSpec" name="LoadBalancerSpec" onchange="check()">
+                    <option value="slb.s1.small">slb.s1.small</option>
+                    <option value="slb.s2.small">slb.s2.small</option>
+                    <option value="slb.s2.medium">slb.s2.medium</option>
+                    <option value="slb.s3.small">slb.s3.small</option>
+                    <option value="slb.s3.medium">slb.s3.medium</option>
+                    <option value="slb.s3.large">slb.s3.large</option>
+                </select>
+            </div>
+        </div>
           <div class="form-group">
             <label for="Bandwidth" class="col-sm-2 control-label">带宽峰值</label>
             <div class="col-sm-10">

--- a/ui/for_hubble/slb.php
+++ b/ui/for_hubble/slb.php
@@ -164,6 +164,14 @@ $myIdx=(isset($_GET['idx'])&&!empty($_GET['idx']))?trim($_GET['idx']):0;
                         <div class="hidden">
                           <input type="hidden" id="tab" name="tab" value="slb">
                         </div>
+                          <div class="col-sm-5" style="padding-left:0px;">
+                              <div class="input-group">
+                                  <span class="input-group-addon">阿里云KeyId</span>
+                                  <select class="form-control" id="fKeyId" onchange="getList('slb')">
+                                      <option value="">请选择</option>
+                                  </select>
+                              </div>
+                          </div>
                         <div class="col-sm-4" style="padding-left:0px;">
                           <div class="input-group">
                             <span class="input-group-addon">地域</span>
@@ -452,6 +460,7 @@ $myIdx=(isset($_GET['idx'])&&!empty($_GET['idx']))?trim($_GET['idx']):0;
       }
     });
     cache.region_id=<?php echo $myIdx;?>;
+    getCloudAccount();
     window.setTimeout("getList()",200);
   });
   $("#myModal").on("shown.bs.modal", function(){

--- a/ui/include/cloud.php
+++ b/ui/include/cloud.php
@@ -38,9 +38,18 @@ class cloud{
         'Authorization: '.$token,
         'X-CORRELATION-ID: ' . $this->reqid,
       );
+
       $url = $this -> domain . '/v1/' . $module;
       if($id) $url.='/' . $id;
       if($method == 'GET' || $method == 'DELETE') $url.=(is_array($data) && !empty($data)) ? '?'.http_build_query($data) : $data;
+
+      if(isset($_REQUEST['fKeyId']) && !empty($_REQUEST['fKeyId']) && ($method == 'POST' || $method == 'PUT' || $method == 'DELETE')) {
+        if(strpos($url, '?') !== false) {
+          $url .= '&keyId=' . $_REQUEST['fKeyId'];
+        } else {
+          $url .= '?keyId=' . $_REQUEST['fKeyId'];
+        }
+      }
 
       $handle = curl_init();
       curl_setopt($handle, CURLOPT_URL, $url);

--- a/ui/include/repos.php
+++ b/ui/include/repos.php
@@ -19,85 +19,89 @@
  */
 
 
-class repos{
+class repos
+{
 
-  private $domain;
-  private $auth;
-  private $reqid;
+    private $domain;
+    private $auth;
+    private $reqid;
 
-  public function __construct() {
-    $this->domain = REPOS_DOMAIN;
-    $this->auth = REOPS_AUTH;
-    $this->reqid = str_replace(array('0.',' '),'',microtime());
-  }
-
-  function curl($token='', $module = '', $method = '', $data = '', $id = '') {
-    if($module && $method ){
-      $header = array(
-        'accept: application/json',
-        'Content-Type: application/json',
-        'X-HTTP-Method-Override: ' . $method,
-        'Token: '.$token,
-        'X-CORRELATION-ID: ' . $this->reqid,
-      );
-      $url = $this -> domain . '/api/' . $module;
-      if($method == 'GET' || $method == 'DELETE') $url.=(is_array($data))?'?'.http_build_query($data):$data;
-      $handle = curl_init();
-      curl_setopt($handle, CURLOPT_URL, $url);
-      curl_setopt($handle, CURLOPT_HTTPHEADER, $header);
-      curl_setopt($handle, CURLOPT_RETURNTRANSFER, 1);
-      curl_setopt($handle, CURLOPT_TIMEOUT, 10);
-      curl_setopt($handle, CURLOPT_USERPWD, $this->auth);
-      curl_setopt($handle, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-      curl_setopt($handle, CURLOPT_HEADER, 1);
-      curl_setopt($handle, CURLOPT_CUSTOMREQUEST, $method);
-      if($method == 'POST'){
-        curl_setopt($handle, CURLOPT_POST, 1);
-        if(is_array($data)) $data=json_encode($data);
-        curl_setopt($handle, CURLOPT_POSTFIELDS, $data);
-      }
-      $result = curl_exec($handle);
-      $header_size = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
-      $header = explode("\r\n",substr($result,0,$header_size));
-      $arrHeader = array();
-      foreach($header as $v){
-        if(trim($v)==='') continue;
-        if(strpos($v,'HTTP/')!==false){
-          $arrHeader['http_code']=$v;
-          continue;
-        }
-        $kv=strpos($v,':');
-        $arrHeader[substr($v,0,$kv)]=trim(substr($v,$kv+1));
-      }
-      $result = substr($result, $header_size);
-      if($t = json_decode($result,true)) $result = json_encode($t, JSON_UNESCAPED_UNICODE);
-      $http_code = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-      if($http_code < 200 || $http_code >= 300){
-        if($http_code == 0) $result = 'timeout';
-        if($aRe=json_decode($result,true)){
-          if(is_array($aRe['msg'])){
-            $result=$aRe['msg'];
-          }else{
-            if(trim($result)=='') $result='""';
-            return '{"code":1,"http_code":' . $http_code . ',"url":"' . addslashes($url) . '","msg":' . $result . ',"header":' . json_encode($arrHeader) . '}';
-          }
-        }
-        return '{"code":1,"http_code":' . $http_code . ',"url":"' . addslashes($url) . '","msg":"' . preg_replace('/\s+/',' ',$result) . '","header":' . json_encode($arrHeader) . '}';
-      }else{
-        if(trim($result)=='') $result='""';
-        return '{"code":0,"msg":"success","content":'.$result.',"header":' . json_encode($arrHeader) . '}';
-      }
+    public function __construct()
+    {
+        $this->domain = REPOS_DOMAIN;
+        $this->auth = REOPS_AUTH;
+        $this->reqid = str_replace(array('0.', ' '), '', microtime());
     }
-    return false;
-  }
 
-  function get($token='', $module = '', $method = '', $data = '', $id = '') {
-    if($ret = $this -> curl($token, $module, $method, $data, $id)) return $ret;
-    return false;
-  }
+    function curl($token = '', $module = '', $method = '', $data = '', $id = '')
+    {
+        if ($module && $method) {
+            $header = array(
+                'accept: application/json',
+                'Content-Type: application/json',
+                'X-HTTP-Method-Override: ' . $method,
+                'Token: ' . $token,
+                'X-CORRELATION-ID: ' . $this->reqid,
+            );
+            $url = $this->domain . '/api/' . $module;
+            if ($method == 'GET' || $method == 'DELETE') $url .= (is_array($data)) ? '?' . http_build_query($data) : $data;
+            $handle = curl_init();
+            curl_setopt($handle, CURLOPT_URL, $url);
+            curl_setopt($handle, CURLOPT_HTTPHEADER, $header);
+            curl_setopt($handle, CURLOPT_RETURNTRANSFER, 1);
+            curl_setopt($handle, CURLOPT_TIMEOUT, 10);
+            curl_setopt($handle, CURLOPT_USERPWD, $this->auth);
+            curl_setopt($handle, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+            curl_setopt($handle, CURLOPT_HEADER, 1);
+            curl_setopt($handle, CURLOPT_CUSTOMREQUEST, $method);
+            if ($method == 'POST') {
+                curl_setopt($handle, CURLOPT_POST, 1);
+                if (is_array($data)) $data = json_encode($data);
+                curl_setopt($handle, CURLOPT_POSTFIELDS, $data);
+            }
+            $result = curl_exec($handle);
+            $header_size = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
+            $header = explode("\r\n", substr($result, 0, $header_size));
+            $arrHeader = array();
+            foreach ($header as $v) {
+                if (trim($v) === '') continue;
+                if (strpos($v, 'HTTP/') !== false) {
+                    $arrHeader['http_code'] = $v;
+                    continue;
+                }
+                $kv = strpos($v, ':');
+                $arrHeader[substr($v, 0, $kv)] = trim(substr($v, $kv + 1));
+            }
+            $result = substr($result, $header_size);
+            if ($t = json_decode($result, true)) $result = json_encode($t, JSON_UNESCAPED_UNICODE);
+            $http_code = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+            if ($http_code < 200 || $http_code >= 300) {
+                if ($http_code == 0) $result = 'timeout';
+                if ($aRe = json_decode($result, true)) {
+                    if (is_array($aRe['msg'])) {
+                        $result = $aRe['msg'];
+                    } else {
+                        if (trim($result) == '') $result = '""';
+                        return '{"code":1,"http_code":' . $http_code . ',"url":"' . addslashes($url) . '","msg":' . $result . ',"header":' . json_encode($arrHeader) . '}';
+                    }
+                }
+                return '{"code":1,"http_code":' . $http_code . ',"url":"' . addslashes($url) . '","msg":"' . preg_replace('/\s+/', ' ', $result) . '","header":' . json_encode($arrHeader) . '}';
+            } else {
+                if (trim($result) == '') $result = '""';
+                return '{"code":0,"msg":"success","content":' . $result . ',"header":' . json_encode($arrHeader) . '}';
+            }
+        }
+        return false;
+    }
+
+    function get($token = '', $module = '', $method = '', $data = '', $id = '')
+    {
+        if ($ret = $this->curl($token, $module, $method, $data, $id)) return $ret;
+        return false;
+    }
 
 }
 
-$repos=new repos();
+$repos = new repos();
 
 ?>

--- a/ui/js/for_hubble/slb.js
+++ b/ui/js/for_hubble/slb.js
@@ -3,6 +3,7 @@ cache = {
   page_size: 20,
   region_id: '',
   region: [],
+  account: [],
   zone: [],
   vpc: [],
   subnet: [],
@@ -381,7 +382,7 @@ var change=function(step){
   $.ajax({
     type: "POST",
     url: url,
-    data: {"action":action,"fIdx":fIdx,"data":JSON.stringify(postData)},
+    data: {"action":action,"fIdx":fIdx,"data":JSON.stringify(postData),fKeyId:$('#fKeyId').val()},
     dataType: "json",
     success: function (data) {
       //执行结果提示
@@ -420,7 +421,7 @@ var view=function(type,idx){
   var url='',title='',text='',illegal=false,height='',postData={};
   var tStyle='word-break:break-all;word-warp:break-word;';
   url='/api/for_cloud/'+type+'.php';
-  postData={"action":"info","fIdx":idx};
+  postData={"action":"info","fIdx":idx,"fKeyId":$('#fKeyId').val()};
   switch(type){
     case 'slb':
       title='查看详情 - '+idx;
@@ -531,7 +532,7 @@ var check=function(tab){
             if($('#Bandwidth').parent().parent().attr('class').indexOf('hidden')==-1) $('#Bandwidth').parent().parent().addClass('hidden');
           }
           if(AddressType=='internet'&&InternetChargeType=='') disabled=true;
-          if(AddressType=='internet'&&Bandwidth=='') disabled=true;
+          if(AddressType=='internet'&&Bandwidth==''&&InternetChargeType=='paybybandwidth') disabled=true;
           if(VpcId=='') disabled=true;
           if(VSwitchId=='') disabled=true;
           if(SecurityGroup=='') disabled=true;
@@ -840,6 +841,7 @@ var getList=function(type,idx,tab){
       url='/api/for_cloud/slb.php?action=list';
       break;
   }
+
   var postData={'pagesize':1000};
   $('#tab').val(tab);
   var actionDesc='';
@@ -850,6 +852,11 @@ var getList=function(type,idx,tab){
       break;
     case 'slb':
       postData.fRegion=$('#fRegion').val();
+      if(!postData.fRegion) {
+        return false;
+      }
+
+      postData.fKeyId = $('#fKeyId').val();
       actionDesc='AliSLB';
       cache.region_id=postData.fRegion;
       break;
@@ -902,7 +909,7 @@ var getInfo=function(idx){
   url='/api/for_cloud/slb.php';
   if(!idx) idx=$('#fSlb').val();
   if(!idx) return false;
-  postData={"action":"info","fIdx":idx};
+  postData={"action":"info","fIdx":idx,"fKeyId":$('#fKeyId').val()};
   $.ajax({
     type: "POST",
     url: url,
@@ -942,6 +949,12 @@ var getSlbPort=function(idx,j){
   url='/api/for_cloud/slb.php?'+j+'_'+idx;
   if(!idx) return false;
   postData={"action":"info","fIdx":idx};
+
+  fKeyId = $('#fKeyId').val();
+  if(fKeyId) {
+    postData.fKeyId = fKeyId
+  }
+
   $.ajax({
     type: "POST",
     url: url,
@@ -978,10 +991,10 @@ var getDesc=function(type,id,idx,protocol,port){
   url='/api/for_cloud/slb_'+type+'.php';
   switch(type){
     case 'listener':
-      postData={"action":"info","fIdx":idx,"fProtocol":protocol,"fPort":port};
+      postData={"action":"info","fIdx":idx,"fProtocol":protocol,"fPort":port,"fKeyId":$('#fKeyId').val()};
       break;
     case 'backend':
-      postData={"action":"status","fIdx":idx};
+      postData={"action":"status","fIdx":idx,"fKeyId":$('#fKeyId').val()};
       break;
     default:
       return false;
@@ -1128,6 +1141,12 @@ var getZoneId=function(){
     return false;
   }
   var postData={"pagesize":1000,"fIdx":idx};
+
+  fKeyId = $('#fKeyId').val();
+  if(fKeyId) {
+    postData.fKeyId = fKeyId
+  }
+
   $.ajax({
     type: "POST",
     url: url,
@@ -1161,6 +1180,12 @@ var getVpcId=function(){
     return false;
   }
   var postData={"pagesize":1000,"fIdx":idx};
+
+  fKeyId = $('#fKeyId').val();
+  if(fKeyId) {
+    postData.fKeyId = fKeyId
+  }
+
   $.ajax({
     type: "POST",
     url: url,
@@ -1203,6 +1228,10 @@ var getVSwitchId=function(){
     return false;
   }
   var postData={"pagesize":1000,fZone:zone,"fIdx":idx};
+  fKeyId = $('#fKeyId').val();
+  if(fKeyId) {
+    postData.fKeyId = fKeyId
+  }
   $.ajax({
     type: "POST",
     url: url,
@@ -1237,6 +1266,10 @@ var getSecurityGroup=function(){
     return false;
   }
   var postData={"pagesize":1000,fRegion:region,"fIdx":idx};
+  fKeyId = $('#fKeyId').val();
+  if(fKeyId) {
+    postData.fKeyId = fKeyId
+  }
   $.ajax({
     type: "POST",
     url: url,
@@ -1291,6 +1324,9 @@ var updateSelect=function(name,idx,tab){
   if(tab) $('#tab').val(tab);
   var tSelect=$('#'+name),data='';
   switch(name){
+    case 'fKeyId':
+      data=cache.account;
+      break;
     case 'fRegion':
     case 'RegionId':
       data=cache.region;
@@ -1317,6 +1353,11 @@ var updateSelect=function(name,idx,tab){
   tSelect.empty();
   if(data.length>0){
     switch(name){
+      case 'fKeyId':
+        $.each(data,function(k,v){
+          tSelect.append('<option value="' + v.KeyID + '">' + v.KeyID + '</option>');
+        });
+        break;
       case 'fRegion':
         $.each(data,function(k,v){
           tSelect.append('<option value="' + v.RegionName + '">' + v.RegionName + '</option>');
@@ -1400,7 +1441,7 @@ var switchs=function(action,idx,port){
   $.ajax({
     type: "POST",
     url: url,
-    data: {"action":action,"data":JSON.stringify(postData)},
+    data: {"action":action,"data":JSON.stringify(postData),"fKeyId":$('#fKeyId').val()},
     dataType: "json",
     success: function (data) {
       //执行结果提示
@@ -1433,7 +1474,7 @@ var get = function (protocol,port) {
   var idx=$('#LoadBalancerId').val();
   switch (tab){
     default:
-      postData={"action":"info","fIdx":idx,"fProtocol":protocol,"fPort":port};
+      postData={"action":"info","fIdx":idx,"fProtocol":protocol,"fPort":port,"fKeyId":$('#fKeyId').val()};
       break;
   }
   if(idx&&protocol&&port){
@@ -1708,7 +1749,7 @@ var addBackend=function(){
   $.ajax({
     type: "POST",
     url: url,
-    data: {"action":action,"fIdx": $('#fSlb').val(),"data":JSON.stringify(postData)},
+    data: {"fKeyId": $('#fKeyId').val(),"action":action,"fIdx": $('#fSlb').val(),"data":JSON.stringify(postData)},
     dataType: "json",
     success: function (data) {
       //执行结果提示
@@ -1730,6 +1771,33 @@ var addBackend=function(){
     },
     error: function (){
       pageNotify('error','【'+actionDesc+'】操作失败！','错误信息：接口不可用');
+    }
+  });
+}
+
+//载入账号
+var getCloudAccount=function(){
+  var actionDesc="云厂商账号",tSelect='fKeyId';
+  var url='/api/for_cloud/cluster.php?action=getaccount&vendor_type=aliyun';
+  var postData={"pagesize":1000};
+  $.ajax({
+    type: "POST",
+    url: url,
+    data: postData,
+    dataType: "json",
+    success: function (data) {
+      cache.account = (typeof data.content != 'undefined') ? data.content : [];
+      updateSelect(tSelect);
+      if(data.code!=0){
+        pageNotify('error','获取'+actionDesc+'失败！','错误信息：'+data.msg);
+      }else{
+        if(data.content.length==0) pageNotify('warning','获取'+actionDesc+'成功！','数据为空!');
+      }
+    },
+    error: function (){
+      cache.account = [];
+      updateSelect(tSelect);
+      pageNotify('error','获取'+actionDesc+'失败！','错误信息：接口不可用');
     }
   });
 }

--- a/ui/js/locale_messages.js
+++ b/ui/js/locale_messages.js
@@ -7,6 +7,7 @@ locale_messages = {
     "LastestPartNum": false,
     "PartOfInstances": false,
     "Desc": "描述",
+    "Account": "KeyId",
     "CreateTime": "创建时间",
     "DeleteTime": false,
     "Cpu": "CPU",


### PR DESCRIPTION
- 多云对接创建模板时支持指定阿里云账号。
- 创建云主机时自动在模板所属的阿里云账号下创建机器。
- SLB支持阿里云多帐号选择查看，创建，更新配置等功能。
- 移除jupiter/conf/jupiter.json中的云厂商单账号配置，改用多帐号配置。